### PR TITLE
Update custom nginx recipe with max upload

### DIFF
--- a/custom_nginx/attributes/customize.rb
+++ b/custom_nginx/attributes/customize.rb
@@ -1,1 +1,1 @@
-normal[:nginx][:client_max_body_size] = '500m'
+normal[:nginx][:client_max_body_size] = node[:nginx][:client_max_body_size] || '500m'


### PR DESCRIPTION
Allow specifying option for client_max_body_size in cutsom_nginx recipe. Should be backward compatible.
